### PR TITLE
Update course status

### DIFF
--- a/1-Project_Blockchain_solution/1-project_strategy.md
+++ b/1-Project_Blockchain_solution/1-project_strategy.md
@@ -249,9 +249,9 @@ Centralized control and risk of foreclosure if payments are missed.
 
 #### **Government Registries:**
 
-[Understanding Property Deeds](https://www.investopedia.com/articles/realestate/12/property-deeds-and-real-property.asp#:~:text=A%20property%20deed%20is%20a,the%20party%20transferring%20the%20property.) (TBR)
+[Understanding Property Deeds](https://www.investopedia.com/articles/realestate/12/property-deeds-and-real-property.asp#:~:text=A%20property%20deed%20is%20a,the%20party%20transferring%20the%20property.) (Done)
 
-[Guidance for members of the public in UK](https://www.gov.uk/guidance/guidance-for-members-of-the-public) (TBR)
+[Guidance for members of the public in UK](https://www.gov.uk/guidance/guidance-for-members-of-the-public) (in progress)
 
 [World Bank Page](https://www.worldbank.org/en/topic/land/overview) (TBR)
 


### PR DESCRIPTION
This pull request updates the status of government registry reference links in the project strategy documentation. The main changes clarify the progress of research tasks for property deed information and UK public guidance.

Documentation updates:

* Changed the status of the property deed reference from "(TBR)" to "(Done)" in `1-project_strategy.md`, indicating research is complete.
* Updated the status of the UK public guidance link from "(TBR)" to "(in progress)" to reflect ongoing work.