### PR TITLE
Add submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cd13282-blockchain-with-solidity"]
+	path = cd13282-blockchain-with-solidity
+	url = https://github.com/udacity/cd13282-blockchain-with-solidity.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cd13282-blockchain-with-solidity"]
-	path = cd13282-blockchain-with-solidity
+	path = 3-BlockChain_with_Solidity/1-Solidity_syntax/0-BlockchainWithSolidity
 	url = https://github.com/udacity/cd13282-blockchain-with-solidity.git

--- a/3-BlockChain_with_Solidity/1-Solidity_syntax/1-MyFirstContract.sol
+++ b/3-BlockChain_with_Solidity/1-Solidity_syntax/1-MyFirstContract.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+contract MyFirstContract {
+    uint public myFavoriteNumber = 5;
+}


### PR DESCRIPTION
This pull request introduces initial blockchain development setup with Solidity by adding a new submodule, a sample contract, and related references. The most important changes are grouped below:

Project setup with submodule:

* Added `.gitmodules` entry and submodule directory `cd13282-blockchain-with-solidity` to link the Udacity Solidity blockchain repository. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3) [[2]](diffhunk://#diff-7e2e593d595c5fd7e910fa19eb8fbae773e0e63f32f9df4657b58ff892783050R1)

Solidity contract introduction:

* Added `MyFirstContract.sol` containing a basic Solidity contract with a public state variable.

Subproject references:

* Updated subproject commit reference in `3-BlockChain_with_Solidity/1-Solidity_syntax/0-BlockchainWithSolidity` to track the correct commit in the submodule.